### PR TITLE
Added code for opt-in only telemetry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ function init(context: types.IExtensionContext): boolean {
 
   context.registerToDo('import-nmm', 'search', () => ({}), 'import', 'Import from NMM', () => {
     context.api.store.dispatch(setImportStep('start'));
+    context.api.events.emit('analytics-track-click-event', 'Dashboard', 'NMM Import');
   }, () => nmmConfigExists() && gameModeActive(context.api.store),  '', 100);
 
   context.once(() => {


### PR DESCRIPTION
 This MR adds the code required for collecting telemetry in Vortex. This is going to be a totally optional opt-in system for users that want to help improve Vortex by providing us with anonymous usage data.